### PR TITLE
Automatic Arch support and handpicked iasl version

### DIFF
--- a/generate_and_apply_patch.sh
+++ b/generate_and_apply_patch.sh
@@ -6,11 +6,59 @@ BOOT=${1:-/boot}
 IRFS_HOOK="/etc/initramfs-tools/hooks/acpi_override.sh"
 cd `mktemp -d`
 
-# Make sure we have required tools on systems with apt
-if [ -x $(which apt-get) ]; then
-	echo "[*] Installing required tools"
-	sudo apt-get -y install acpica-tools cpio
+###
+# If the tested version of iasl is not currently installed...
+if [ "$(iasl -v | grep -c 20181031)" -eq 0 ]; then
+ 
+ echo "[*] Attempting to install required tools to build iasl"
+ 
+ # Build a newer version of iasl
+ # If on Debian-based distro...
+ if [ -x "$(which apt-get)" ]; then
+     sudo apt-get -y install bison flex
+ # If on Arch-based distro...
+ elif [ -x "$(which pacman)" ]; then
+     sudo pacman -S bison flex
+ else
+     echo "Unable to automatically download and install bison or flex"
+     echo "Manual install needed"
+     exit 1
+ fi
+
+ echo "[*] Upgrading IASL..."
+ wget https://acpica.org/sites/acpica/files/acpica-unix2-20181031.tar.gz 
+ tar -zxf acpica-unix2-20181031.tar.gz
+ cd acpica-unix2-20181031
+ make clean
+ make iasl || { echo 'ERROR: Failed to build IASL' ; exit 1; }
+ sudo make install || { echo 'ERROR: Failed to install new version of IASL' ; exit 1; }
+ cd ..
 fi
+###
+
+###
+# Make sure we have required tools on systems with apt
+echo "[*] Attempting to install required tools"
+
+# If on Debian-based distro...
+if [ -x "$(which apt-get)" ]; then
+    sudo apt-get -y install acpica-tools cpio
+
+# If on Arch-based distro...
+elif [ -x "$(which pacman)" ]; then
+    echo "[*] Installing Yay to be able to download AUR packages"
+    if ![ -x "$(which git)" ]; then
+        sudo pacman -S git
+    fi
+    if ![ -x "$(which yay)" ]; then
+        git clone https://aur.archlinux.org/yay.git
+        cd yay
+        makepkg -si
+    fi
+    echo "Installing cpio"
+    yay -Syu cpio
+fi
+###
 
 # extract dsdt
 echo "[*] Dumping DSDT"

--- a/generate_and_apply_patch.sh
+++ b/generate_and_apply_patch.sh
@@ -42,7 +42,7 @@ echo "[*] Attempting to install required tools"
 
 # If on Debian-based distro...
 if [ -x "$(which apt-get)" ]; then
-    sudo apt-get -y install acpica-tools cpio
+    sudo apt-get -y install cpio
 
 # If on Arch-based distro...
 elif [ -x "$(which pacman)" ]; then


### PR DESCRIPTION
Here's some changes I made to your version of the script with some inspiration from @kdkavanagh ([source](https://github.com/fiji-flo/x1carbon2018s3/pull/25/files/b9cebffaa17b0bf54785132eb15cacdd1efa7958#diff-416b03104be0ddefe128317ef5379382))
## Changelog
- Downloads this specific version of iasl (https://acpica.org/sites/acpica/files/acpica-unix2-20181031.tar.gz)
- Detects if the user is running a Debian/Ubuntu based distro or an Arch based distro by checking which package manager is installed.
- Removed the outdated "acpi-tools" from being installed bia apt-get because a newer version was aleady manually picked out and installed.

## Room for improvement
I ended up leaving a trail of installation tools installed that some end users might not want to keep on their system. I tried to avoid having to install Yay, but it was just simpler for me to install it an use it.

I'm still a little new to using git, so I accidentally pushed to my forked master branch first, so I merged it with the x1y3 branch and reverted the commit to the master branch after that.